### PR TITLE
Add test around logging with WeShipClient.logger

### DIFF
--- a/lib/we_ship_client.rb
+++ b/lib/we_ship_client.rb
@@ -10,6 +10,6 @@ require 'we_ship_client/transforms/tracking_item'
 
 module WeShipClient
   def self.logger
-    defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
+    @logger ||= defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
   end
 end

--- a/spec/we_ship_client/interactors/get_tracking_spec.rb
+++ b/spec/we_ship_client/interactors/get_tracking_spec.rb
@@ -116,7 +116,12 @@ RSpec.describe WeShipClient::Interactors::GetTracking do
         let(:auth_token) { 'invalid-jwt' }
         let(:cassette_name) { 'interactors/get_tracking/invalid_jwt' }
 
-        it { is_expected.to raise_error(WeShipClient::Exceptions::AuthenticationError) }
+        it 'logs error' do
+          expect(WeShipClient.logger).to receive(:info)
+            .with(/EXCEPTION/).and_call_original
+
+          expect { subject.call }.to raise_error(WeShipClient::Exceptions::AuthenticationError)
+        end
       end
 
       context 'when there is a different error' do
@@ -126,7 +131,12 @@ RSpec.describe WeShipClient::Interactors::GetTracking do
           WeShipClient::Entities::TrackRequest.new(order_id: ['123789'], customer_code: customer_code)
         end
 
-        it { is_expected.to raise_error(WeShipClient::Exceptions::ServerError) }
+        it 'logs and raises error' do
+          expect(WeShipClient.logger).to receive(:info)
+            .with(/EXCEPTION/).and_call_original
+
+          expect { subject.call }.to raise_error(WeShipClient::Exceptions::ServerError)
+        end
       end
 
       context 'when response is 503 HTTP ' do


### PR DESCRIPTION
We received a bug around `undefined method 'logger'` for WeShipClient module, and so adding some specs around calling it to verify it works as expected.